### PR TITLE
only run modifications if the modifers don't match

### DIFF
--- a/src/main/java/io/papermc/restamp/RestampContextConfiguration.java
+++ b/src/main/java/io/papermc/restamp/RestampContextConfiguration.java
@@ -120,7 +120,7 @@ public record RestampContextConfiguration(
          * @return this builder.
          */
         @NotNull
-        @Contract(value = "_,_ -> this", mutates = "this")
+        @Contract(value = "_ -> this", mutates = "this")
         public Builder accessTransformSet(@NotNull final AccessTransformSet accessTransformSet) {
             this.accessTransformSet = AccessTransformSet.create();
             this.accessTransformSet.merge(accessTransformSet);

--- a/src/main/java/io/papermc/restamp/at/ModifierTransformationProgress.java
+++ b/src/main/java/io/papermc/restamp/at/ModifierTransformationProgress.java
@@ -182,7 +182,7 @@ public class ModifierTransformationProgress {
      */
     @NotNull
     public Result finaliseProgress(
-        @NotNull final Supplier<J.Modifier> visibilityModifierCreator,
+        @Nullable final Supplier<J.Modifier> visibilityModifierCreator,
         @NotNull Space parentSpace
     ) {
         // If we neither found the visibility nor found ones to remove, pretend we found a valid spot at index 0.
@@ -206,7 +206,7 @@ public class ModifierTransformationProgress {
         }
 
         // Insert if the spot is still useful, the visibility was not found.
-        if (this.validVisibilitySpot.useful) {
+        if (this.validVisibilitySpot.useful && visibilityModifierCreator != null) {
             this.modifiers.add(this.validVisibilitySpot.index, visibilityModifierCreator.get());
             this.mutatedFromOriginal = true;
         }

--- a/src/main/java/io/papermc/restamp/at/ModifierTransformer.java
+++ b/src/main/java/io/papermc/restamp/at/ModifierTransformer.java
@@ -78,6 +78,9 @@ public class ModifierTransformer {
                 continue;
             }
 
+            // Do not touch access modifiers if no change was requested.
+            if (accessTransform.getAccess() == AccessChange.NONE) continue;
+
             // Drop unwanted visibility modifiers and record potential position for new modifier.
             if (modifier.getType() != accessTypeToKeep) {
                 transformationProgress.dropModifier(modifier);
@@ -90,8 +93,9 @@ public class ModifierTransformer {
         }
 
         // Finalise the progress tracker
+        // Only pass a modifier creator if we are requesting access change in the first place
         final ModifierTransformationProgress.Result result = transformationProgress.finaliseProgress(
-            () -> new J.Modifier(
+            accessTransform.getAccess() == AccessChange.NONE ? null : () -> new J.Modifier(
                 Tree.randomId(), Space.EMPTY, Markers.EMPTY, null,
                 Objects.requireNonNull(accessTypeToKeep, "package private caused insertion"), Collections.emptyList()
             ),

--- a/src/main/java/io/papermc/restamp/at/ModifierTransformer.java
+++ b/src/main/java/io/papermc/restamp/at/ModifierTransformer.java
@@ -78,11 +78,9 @@ public class ModifierTransformer {
                 continue;
             }
 
-            // Do not touch access modifiers if no change was requested.
-            if (accessTransform.getAccess() == AccessChange.NONE) continue;
-
             // Drop unwanted visibility modifiers and record potential position for new modifier.
-            if (modifier.getType() != accessTypeToKeep) {
+            // Do not touch access modifiers if no change was requested.
+            if (accessTransform.getAccess() != AccessChange.NONE && modifier.getType() != accessTypeToKeep) {
                 transformationProgress.dropModifier(modifier);
                 transformationProgress.proposeValidVisibilitySpot();
                 continue;

--- a/src/main/java/io/papermc/restamp/recipe/ClassATMutator.java
+++ b/src/main/java/io/papermc/restamp/recipe/ClassATMutator.java
@@ -53,13 +53,15 @@ public class ClassATMutator extends Recipe {
                 final AccessTransform accessTransform = transformerClass.get();
                 if (accessTransform.isEmpty()) return classDeclaration;
 
-                transformerClass.replace(AccessTransform.EMPTY); // Mark as consumed
-
                 final ModifierTransformationResult transformationResult = modifierTransformer.transformModifiers(
                     accessTransform,
                     classDeclaration.getModifiers(),
                     classDeclaration.getAnnotations().getKind().getPrefix()
                 );
+                if (transformationResult.newModifiers().equals(classDeclaration.getModifiers())) {
+                    return classDeclaration;
+                }
+                transformerClass.replace(AccessTransform.EMPTY); // Mark as consumed
 
                 return classDeclaration
                     .withModifiers(transformationResult.newModifiers())

--- a/src/main/java/io/papermc/restamp/recipe/FieldATMutator.java
+++ b/src/main/java/io/papermc/restamp/recipe/FieldATMutator.java
@@ -60,7 +60,7 @@ public class FieldATMutator extends Recipe {
 
                 // Fetch access transformer to apply to specific field.
                 final AccessTransform accessTransformToApply = variableDeclarations.getVariables().stream()
-                    .map(n -> transformerClass.replaceField(n.getSimpleName(), AccessTransform.EMPTY))
+                    .map(n -> transformerClass.getField(n.getSimpleName()))
                     .filter(Objects::nonNull)
                     .reduce(AccessTransform::merge)
                     .orElse(AccessTransform.EMPTY);
@@ -72,6 +72,12 @@ public class FieldATMutator extends Recipe {
                     variableDeclarations.getModifiers(),
                     Optional.ofNullable(variableDeclarations.getTypeExpression()).map(J::getPrefix).orElse(Space.EMPTY)
                 );
+
+                if (transformationResult.newModifiers().equals(variableDeclarations.getModifiers())) {
+                    return variableDeclarations;
+                }
+                variableDeclarations.getVariables().forEach(n -> transformerClass.replaceField(n.getSimpleName(), AccessTransform.EMPTY)); // Mark as consumed
+
                 final J.VariableDeclarations updated = variableDeclarations
                     .withModifiers(transformationResult.newModifiers())
                     .withTypeExpression(variableDeclarations.getTypeExpression().withPrefix(transformationResult.parentSpace()));

--- a/src/main/java/io/papermc/restamp/recipe/MethodATMutator.java
+++ b/src/main/java/io/papermc/restamp/recipe/MethodATMutator.java
@@ -100,9 +100,9 @@ public class MethodATMutator extends Recipe {
                     returnType = VoidType.INSTANCE;
                 }
 
-                final AccessTransform accessTransform = transformerClass.replaceMethod(new MethodSignature(
+                final AccessTransform accessTransform = transformerClass.getMethod(new MethodSignature(
                     atMethodName, new MethodDescriptor(parameterTypes, returnType)
-                ), AccessTransform.EMPTY);
+                ));
                 if (accessTransform == null || accessTransform.isEmpty()) return methodDeclaration;
 
                 final TypeTree returnTypeExpression = methodDeclaration.getReturnTypeExpression();
@@ -111,6 +111,13 @@ public class MethodATMutator extends Recipe {
                     methodDeclaration.getModifiers(),
                     Optional.ofNullable(returnTypeExpression).map(J::getPrefix).orElse(methodDeclaration.getName().getPrefix())
                 );
+
+                if (transformationResult.newModifiers().equals(methodDeclaration.getModifiers())) {
+                    return methodDeclaration;
+                }
+                transformerClass.replaceMethod(new MethodSignature(
+                    atMethodName, new MethodDescriptor(parameterTypes, returnType)
+                ), AccessTransform.EMPTY); // Mark as consumed
 
                 J.MethodDeclaration updated = methodDeclaration.withModifiers(transformationResult.newModifiers());
                 if (returnTypeExpression != null) {

--- a/src/test/java/io/papermc/restamp/at/ModifierTransformerTest.java
+++ b/src/test/java/io/papermc/restamp/at/ModifierTransformerTest.java
@@ -69,11 +69,12 @@ class ModifierTransformerTest {
 
     @ParameterizedTest
     @ArgumentsSource(RestampFunctionTestHelper.CartesianVisibilityArgumentProvider.class)
-    public void testModifyVisibilityTransformation(@NotNull final AccessTransform current,
-                                                   @NotNull final AccessTransform wanted,
+    public void testModifyVisibilityTransformation(@NotNull final AccessTransform currentState,
+                                                   @NotNull final AccessTransform targetState,
+                                                   @NotNull final AccessTransform instruction,
                                                    @Nullable final String staticModifierExisting) {
         final List<J.Modifier> modifiers = new ArrayList<>();
-        final J.Modifier.Type type = switch (current.getAccess()) {
+        final J.Modifier.Type type = switch (currentState.getAccess()) {
             case PRIVATE -> J.Modifier.Type.Private;
             case PROTECTED -> J.Modifier.Type.Protected;
             case PUBLIC -> J.Modifier.Type.Public;
@@ -83,23 +84,23 @@ class ModifierTransformerTest {
             modifiers.add(modifierFrom(Space.EMPTY, type));
         }
         if (staticModifierExisting != null) modifiers.add(modifierFrom(Space.SINGLE_SPACE, J.Modifier.Type.Static));
-        if (current.getFinal() == ModifierChange.ADD) modifiers.add(modifierFrom(Space.SINGLE_SPACE, J.Modifier.Type.Final));
+        if (currentState.getFinal() == ModifierChange.ADD) modifiers.add(modifierFrom(Space.SINGLE_SPACE, J.Modifier.Type.Final));
 
-        final ModifierTransformationResult result = transformer.transformModifiers(wanted, modifiers, Space.SINGLE_SPACE);
+        final ModifierTransformationResult result = transformer.transformModifiers(instruction, modifiers, Space.SINGLE_SPACE);
 
         final List<J.Modifier> newModifiers = result.newModifiers();
 
         int expectedModifierSize = 0;
-        if (wanted.getAccess() != AccessChange.PACKAGE_PRIVATE) expectedModifierSize++;
-        if (wanted.getFinal() == ModifierChange.ADD) expectedModifierSize++;
+        if (targetState.getAccess() != AccessChange.PACKAGE_PRIVATE) expectedModifierSize++;
+        if (targetState.getFinal() == ModifierChange.ADD) expectedModifierSize++;
         if (staticModifierExisting != null) expectedModifierSize++;
 
         Assertions.assertEquals(expectedModifierSize, newModifiers.size());
-        if (wanted.getAccess() != AccessChange.PACKAGE_PRIVATE) {
-            Assertions.assertEquals(RecipeHelper.typeFromAccessChange(wanted.getAccess()), newModifiers.remove(0).getType());
+        if (targetState.getAccess() != AccessChange.PACKAGE_PRIVATE) {
+            Assertions.assertEquals(RecipeHelper.typeFromAccessChange(targetState.getAccess()), newModifiers.remove(0).getType());
         }
         if (staticModifierExisting != null) Assertions.assertEquals(J.Modifier.Type.Static, newModifiers.remove(0).getType());
-        if (wanted.getFinal() == ModifierChange.ADD) Assertions.assertEquals(J.Modifier.Type.Final, newModifiers.remove(0).getType());
+        if (targetState.getFinal() == ModifierChange.ADD) Assertions.assertEquals(J.Modifier.Type.Final, newModifiers.remove(0).getType());
     }
 
     @Test

--- a/src/test/java/io/papermc/restamp/function/RestampClassFunctionTest.java
+++ b/src/test/java/io/papermc/restamp/function/RestampClassFunctionTest.java
@@ -26,9 +26,10 @@ public class RestampClassFunctionTest {
     @ArgumentsSource(RestampFunctionTestHelper.CartesianVisibilityArgumentProvider.class)
     public void testAccessTransformerOnClass(@NotNull final AccessTransform given,
                                              @NotNull final AccessTransform target,
+                                             @NotNull final AccessTransform instruction,
                                              @Nullable final String staticModifier) {
         final AccessTransformSet accessTransformSet = AccessTransformSet.create();
-        accessTransformSet.getOrCreateClass("io.papermc.test.Test").replace(target);
+        accessTransformSet.getOrCreateClass("io.papermc.test.Test").replace(instruction);
 
         final RestampInput input = RestampFunctionTestHelper.inputFromSourceString(accessTransformSet, constructClassTest(
             accessChangeToModifierString(given.getAccess(), staticModifier, given.getFinal() == ModifierChange.ADD ? "final" : null)

--- a/src/test/java/io/papermc/restamp/function/RestampFieldFunctionTest.java
+++ b/src/test/java/io/papermc/restamp/function/RestampFieldFunctionTest.java
@@ -26,9 +26,10 @@ public class RestampFieldFunctionTest {
     @ArgumentsSource(RestampFunctionTestHelper.CartesianVisibilityArgumentProvider.class)
     public void testAccessTransformerOnField(@NotNull final AccessTransform given,
                                              @NotNull final AccessTransform target,
+                                             @NotNull final AccessTransform instruction,
                                              @Nullable final String staticModifier) {
         final AccessTransformSet accessTransformSet = AccessTransformSet.create();
-        accessTransformSet.getOrCreateClass("io.papermc.test.Test").replaceField("passphrase", target);
+        accessTransformSet.getOrCreateClass("io.papermc.test.Test").replaceField("passphrase", instruction);
 
         final RestampInput input = RestampFunctionTestHelper.inputFromSourceString(accessTransformSet, constructFieldTest(
             accessChangeToModifierString(given.getAccess(), staticModifier, given.getFinal() == ModifierChange.ADD ? "final" : null)

--- a/src/test/java/io/papermc/restamp/function/RestampMethodFunctionTest.java
+++ b/src/test/java/io/papermc/restamp/function/RestampMethodFunctionTest.java
@@ -27,10 +27,11 @@ public class RestampMethodFunctionTest {
     @ArgumentsSource(RestampFunctionTestHelper.CartesianVisibilityArgumentProvider.class)
     public void testAccessTransformerOnMethod(@NotNull final AccessTransform given,
                                               @NotNull final AccessTransform target,
+                                              @NotNull final AccessTransform instruction,
                                               @Nullable final String staticModifier) {
         final AccessTransformSet accessTransformSet = AccessTransformSet.create();
         accessTransformSet.getOrCreateClass("io.papermc.test.Test").replaceMethod(
-            MethodSignature.of("test", "(Ljava.lang.Object;)Ljava.lang.String;"), target
+            MethodSignature.of("test", "(Ljava.lang.Object;)Ljava.lang.String;"), instruction
         );
 
         final RestampInput input = RestampFunctionTestHelper.inputFromSourceString(accessTransformSet, constructMethodTest(


### PR DESCRIPTION
I haven't tested this in a real-world scenario yet, need @MiniDigger 's DiffPatch stuff cause that's what paperweight is using now.